### PR TITLE
chore(deps-dev): remove unnecessary @types/eslint__js

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@octokit/openapi-types": "24.0.0",
     "@octokit/webhooks-types": "7.6.1",
     "@types/eslint-config-prettier": "6.11.3",
-    "@types/eslint__js": "8.42.3",
     "@types/jest": "29.5.14",
     "@types/node": "22.13.5",
     "@vercel/ncc": "0.38.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@types/eslint-config-prettier':
         specifier: 6.11.3
         version: 6.11.3
-      '@types/eslint__js':
-        specifier: 8.42.3
-        version: 8.42.3
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -514,12 +511,6 @@ packages:
 
   '@types/eslint-config-prettier@6.11.3':
     resolution: {integrity: sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
-  '@types/eslint__js@8.42.3':
-    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -2527,15 +2518,6 @@ snapshots:
       '@babel/types': 7.26.9
 
   '@types/eslint-config-prettier@6.11.3': {}
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.6
-      '@types/json-schema': 7.0.15
-
-  '@types/eslint__js@8.42.3':
-    dependencies:
-      '@types/eslint': 9.6.1
 
   '@types/estree@1.0.6': {}
 


### PR DESCRIPTION
This package is a stub type definition and is not needed because @eslint/js provides its own type definitions.
