### PR TITLE
ci: specify permissions for generated app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           app-id: ${{ secrets.MAZI_RELEASE_APP_ID }}
           private-key: ${{ secrets.MAZI_RELEASE_APP_PRIVATE_KEY }}
+          # Limit token permissions to only what's needed for release-please
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release-please
         with:


### PR DESCRIPTION
Uses the `permission-*` inputs of the `create-github-app-token` action to explicitly grant only necessary permissions (`contents: write`, `pull-requests: write`) to the generated token, following security best practices. This limits the scope of the token generated for release-please step.
